### PR TITLE
feat: package grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,36 @@
   "prCreation": "not-pending",
   "timezone": "Europe/Paris",
   "schedule": "after 4am and before 9am every weekday",
-  "lockfileMaintenance": true
+  "lockfileMaintenance": true,
+  "packageRules": [
+    {
+      "packageNames": ["capnp", "capnpc"],
+      "groupName": "capnp packages"
+    },
+    {
+      "packagePatterns": ["^futures[-_]?"],
+      "groupName": "futures packages"
+    },
+    {
+      "packagePatterns": ["^opentelemetry[-_]?", "^tracing-opentelemetry$"],
+      "groupName": "opentelemetry packages"
+    },
+    {
+      "packagePatterns": ["^prost[-_]?"],
+      "groupName": "prost packages"
+    },
+    {
+      "packagePatterns": ["^rusoto[-_]?"],
+      "groupName": "rusoto packages"
+    },
+    {
+      "packagePatterns": ["^serde[-_]?"],
+      "groupName": "serde packages"
+    },
+    {
+      "packagePatterns": ["^tracing[-_]?"],
+      "excludePackageNames": ["tracing-opentelemetry"],
+      "groupName": "tracing packages"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
-    "description": "Shared Renovate configuration for Netlify Rust repositories",
-    "dependencyDashboard": true,
-    "prCreation": "not-pending",
-    "timezone": "Europe/Paris",
-    "schedule": "after 4am and before 9am every weekday",
-    "lockfileMaintenance": true
+  "description": "Shared Renovate configuration for Netlify Rust repositories",
+  "dependencyDashboard": true,
+  "prCreation": "not-pending",
+  "timezone": "Europe/Paris",
+  "schedule": "after 4am and before 9am every weekday",
+  "lockfileMaintenance": true
 }


### PR DESCRIPTION
Some rust crates are often version-bumped at the same time since they are managed in a monorepo.

This is especially useful with breaking changes where you need to update crates simultaneously.